### PR TITLE
increase max characters for movie description

### DIFF
--- a/server/src/main/java/org/launchcode/couchcatbackend/models/Movie.java
+++ b/server/src/main/java/org/launchcode/couchcatbackend/models/Movie.java
@@ -20,11 +20,13 @@ public class Movie {
     private String title;
     private int year;
 
-    @Size(max = 1000)
+    @Column(columnDefinition="TEXT", length = 3000)
     private String description;
 
     @Size(max = 100)
     private String director;
+
+    @Size(max = 255)
     private String cast;
     private float rating;
 


### PR DESCRIPTION
Minor fix to the Movie class so that MySQL will store the "description" column as "text" data type with a limit of 3000 characters instead of "varchar" with a limit of 255. I tested this by loading the entire prologue of "Middlemarch" into the description column for a movie. It worked.

(unrelated to whitelisting pages but didn't seem like a big enough fix to make a new branch)